### PR TITLE
Call `npm version` with `--no-git-tag-version` for release builds

### DIFF
--- a/scripts/node_version.sh
+++ b/scripts/node_version.sh
@@ -10,7 +10,7 @@ export TAG=''
 # for main do prereleases
 if [[ "$GITHUB_REF" =~ ^refs/tags/v.+$ ]] ; then
 	# proper release
-	npm version `echo $GITHUB_REF | sed 's|refs/tags/v||'`
+	npm version --no-git-tag-version `echo $GITHUB_REF | sed 's|refs/tags/v||'`
 else
 	git describe --tags --long || exit
 


### PR DESCRIPTION
This should fix future release builds, but 0.9.1 will need to still be fixed manually
