### PR TITLE
CI: anchor Python version to 3.11

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -142,6 +142,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Default Python (3.12) doesn't have support for distutils
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
         with:


### PR DESCRIPTION
This is an upstream problem in node-gyp, can be potentially be worked around like in this PR if I had gotten the syntax right.

See for context: https://github.com/nodejs/node-gyp/issues/2869