### PR TITLE
Set duckdb_api to nodejs

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -33,6 +33,7 @@ struct OpenTask : public Task {
 	    : Task(database_, callback_), filename(filename_) {
 
 		duckdb_config.options.access_mode = access_mode_;
+		duckdb_config.SetOptionByName("duckdb_api", duckdb::Value("nodejs"));
 		Napi::Env env = database_.Env();
 		Napi::HandleScope scope(env);
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,30 @@
+import * as duckdb from '..';
+import * as assert from 'assert';
+import {TableData} from "..";
+
+describe('user_agent', () => {
+
+    it('default value', (done) => {
+        const db: duckdb.Database = new duckdb.Database(':memory:');
+
+        db.all('PRAGMA USER_AGENT', (err: null | Error, rows: TableData) => {
+            if (err) {
+                throw err;
+            }
+            assert.match(rows[0].user_agent, /duckdb\/.*\(*\) nodejs/);
+            done();
+        });
+    })
+
+    it('with custom_user_agent', (done) => {
+        const db: duckdb.Database = new duckdb.Database(':memory:', { 'custom_user_agent': 'a_framework' });
+
+        db.all('PRAGMA USER_AGENT', (err: null | Error, rows: TableData) => {
+            if (err) {
+                throw err;
+            }
+            assert.match(rows[0].user_agent, /duckdb\/.*\(*\) nodejs a_framework/);
+            done();
+        });
+    })
+})


### PR DESCRIPTION
DuckDB 0.9.2 introduced `PRAGMA user_agent` composed of `duckdb_api` and `custom_user_agent`. This PR sets `duckdb_api` component to `nodejs`. 