### PR TITLE
Serve binaries from https://npm.duckdb.org

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -73,6 +73,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Default Python (3.12) doesn't have support for distutils
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - name: Update apt
         shell: bash
         run: |
@@ -102,6 +107,10 @@ jobs:
           npm_config_yes: true
 
       - name: Node ${{ matrix.node }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
+          AWS_DEFAULT_REGION: us-east-1
         shell: bash
         run: ./scripts/node_build.sh ${{ matrix.node }}
 
@@ -166,6 +175,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
 
       - name: Node ${{ matrix.node }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
+          AWS_DEFAULT_REGION: us-east-1
         shell: bash
         run: ./scripts/node_build.sh ${{ matrix.node }}
 
@@ -199,9 +212,10 @@ jobs:
             node: 20
 
     steps:
+      # Default Python (3.12) doesn't have support for distutils
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - uses: actions/checkout@v3
         with:
@@ -238,5 +252,9 @@ jobs:
           variant: sccache
 
       - name: Node
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
+          AWS_DEFAULT_REGION: us-east-1
         shell: bash
         run: ./scripts/node_build_win.sh

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       matrix:
         target_arch: [ x64, arm64 ]
-        node: [ '12', '14', '16', '17', '18', '19', '20', '21']
+        node: [ '16', '17', '18', '19', '20', '21']
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
         exclude:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "binary": {
     "module_name": "duckdb",
     "module_path": "./lib/binding/",
-    "host": "https://duckdb-node.s3.amazonaws.com"
+    "host": "https://npm.duckdb.org/duckdb"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",

--- a/scripts/node_build.sh
+++ b/scripts/node_build.sh
@@ -37,7 +37,7 @@ export PATH=$(npm bin):$PATH
 
 LOCAL_BINARY=$(./node_modules/.bin/node-pre-gyp reveal staged_tarball --silent)
 REMOTE_BINARY=$(./node_modules/.bin/node-pre-gyp reveal hosted_tarball --silent)
-s3_ENDPOINT_BINARY="s3://duckdb-npm/"${REMOTE_BINARY:23}
+S3_ENDPOINT_BINARY="s3://duckdb-npm/"${REMOTE_BINARY:23}
 
 pip install awscli
 

--- a/scripts/node_build.sh
+++ b/scripts/node_build.sh
@@ -34,7 +34,19 @@ fi
 
 export PATH=$(npm bin):$PATH
 ./node_modules/.bin/node-pre-gyp package testpackage testbinary --target_arch="$TARGET_ARCH"
+
+LOCAL_BINARY=$(./node_modules/.bin/node-pre-gyp reveal staged_tarball --silent)
+REMOTE_BINARY=$(./node_modules/.bin/node-pre-gyp reveal hosted_tarball --silent)
+s3_ENDPOINT_BINARY="s3://duckdb-npm/"${REMOTE_BINARY:23}
+
+pip install awscli
+
+echo "local binary at  $LOCAL_BINARY"
+echo "remote binary at $REMOTE_BINARY"
+echo "served from      $S3_ENDPOINT_BINARY"
+
 if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ ]] ; then
-  ./node_modules/.bin/node-pre-gyp publish --target_arch=$TARGET_ARCH
-  ./node_modules/.bin/node-pre-gyp info --target_arch=$TARGET_ARCH
+  aws s3 cp $LOCAL_BINARY $S3_ENDPOINT_BINARY --acl public-read
+else
+  aws s3 cp $LOCAL_BINARY $S3_ENDPOINT_BINARY --acl public-read --dryrun
 fi

--- a/scripts/node_build_win.sh
+++ b/scripts/node_build_win.sh
@@ -15,7 +15,18 @@ if [[ ! "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
 fi
 npx node-pre-gyp package testpackage testbinary
 
+LOCAL_BINARY=$(./node_modules/.bin/node-pre-gyp reveal staged_tarball --silent)
+REMOTE_BINARY=$(./node_modules/.bin/node-pre-gyp reveal hosted_tarball --silent)
+s3_ENDPOINT_BINARY="s3://duckdb-npm/"${REMOTE_BINARY:23}
+
+pip install awscli
+
+echo "local binary at  $LOCAL_BINARY"
+echo "remote binary at $REMOTE_BINARY"
+echo "served from      $S3_ENDPOINT_BINARY"
+
 if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ ]] ; then
-  npx node-pre-gyp publish
-  npx node-pre-gyp info
+  aws s3 cp $LOCAL_BINARY $S3_ENDPOINT_BINARY --acl public-read
+else
+  aws s3 cp $LOCAL_BINARY $S3_ENDPOINT_BINARY --acl public-read --dryrun
 fi

--- a/scripts/node_build_win.sh
+++ b/scripts/node_build_win.sh
@@ -17,7 +17,7 @@ npx node-pre-gyp package testpackage testbinary
 
 LOCAL_BINARY=$(./node_modules/.bin/node-pre-gyp reveal staged_tarball --silent)
 REMOTE_BINARY=$(./node_modules/.bin/node-pre-gyp reveal hosted_tarball --silent)
-s3_ENDPOINT_BINARY="s3://duckdb-npm/"${REMOTE_BINARY:23}
+S3_ENDPOINT_BINARY="s3://duckdb-npm/"${REMOTE_BINARY:23}
 
 pip install awscli
 


### PR DESCRIPTION
Things to check:
* if those secrets exists (and have the access rights)
          AWS_ACCESS_KEY_ID: ${{secrets.S3_ID}}
          AWS_SECRET_ACCESS_KEY: ${{secrets.S3_KEY}}
potentially they need to be changed to right [organization] secrets.

* check (on this PR CI) whether the aws s3 cp instruction make sense (are issued with --dryrun)
* test this end to end on a NON tagged version (basically merging this PR, waiting for CI to go through, check what happens by installing locally `npm install duckdb@next`. Ideally checking also windows / linux.

Note that I disabled OSX node 12 and 14 also for amd64 since they seems to have problem in CI (https://github.com/duckdb/duckdb-node/actions/runs/7956650640/job/21718762716). Unsure if support can /should be restored back, have not tried.
Also Windows CI seems to have problems, but that's due to Chocolately outage that will eventually be solved.

Solves #8 