### PR TITLE
Fixes Database.stream is not a function exception

### DIFF
--- a/lib/duckdb.js
+++ b/lib/duckdb.js
@@ -530,6 +530,17 @@ Database.prototype.each = function () {
     return this;
 }
 
+
+/**
+ * @arg sql
+ * @param {...*} params
+ * @yields row chunks
+ */
+Database.prototype.stream = function() {
+    return default_connection(this).stream.apply(this.default_connection, arguments);
+}
+
+
 /**
  * Convenience method for Connection#apply using a built-in default connection
  * @arg sql

--- a/test/query_result.test.ts
+++ b/test/query_result.test.ts
@@ -20,4 +20,13 @@ describe('QueryResult', () => {
         }
         assert.equal(total, retrieved)
     })
+
+    it('streams results using the database object', async () => {
+        let retrieved = 0;
+        const stream = db.stream('SELECT * FROM range(0, ?)', total);
+        for await (const row of stream) {
+            retrieved++;
+        }
+        assert.equal(total, retrieved)
+    })
 })


### PR DESCRIPTION
There is a stream method mentioned in the [declaration of of the database class](https://github.com/duckdb/duckdb-node/blob/a62d0961d46e83e44241f3424b1c8844fd0b18e1/lib/duckdb.d.ts#L169) however this method does not exist, resulting in the following error for this code:

```typescript
import {Database} from "duckdb-async";
// ...

const db = await Database.create(":memory:");

// TypeError: this.db.stream is not a function
for await (const res of db.stream("select CAST(range as INTEGER) as range from range(1,10)")) {
    console.log(res);
}
``` 

This PR adds the method that should exist to the Database. 


PS: Both tests in *each.test.ts* fail (one is disabled, but fails if you enable it), but they did that even before the changes