### PR TITLE
Do not package for Node version 12 and 14

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -118,7 +118,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb-node'
     name: node.js OSX
     runs-on: macos-latest
-    needs: linux-nodejs
+    needs: set-up-npm
     continue-on-error: ${{ matrix.node != '18' && matrix.node != '20' && matrix.node != '21' }}
     strategy:
       matrix:
@@ -185,7 +185,7 @@ jobs:
   win-nodejs:
     name: node.js Windows
     runs-on: windows-latest
-    needs: linux-nodejs
+    needs: set-up-npm
     continue-on-error: ${{ matrix.node != '18' && matrix.node != '20' && matrix.node != '21' }}
     env:
       npm_config_msvs_version: 2019

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         # node.js current support policy to be found at https://github.com/duckdb/duckdb-node/tree/main/#Supported-Node-versions
-        node: [ '12', '14', '16', '17', '18', '19', '20', '21']
+        node: [ '16', '17', '18', '19', '20', '21']
         target_arch: [ x64, arm64 ]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
@@ -192,7 +192,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [ '12', '14', '16', '17', '18', '19', '20', '21']
+        node: [ '16', '17', '18', '19', '20', '21']
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
         exclude:


### PR DESCRIPTION
To be reviewed whether we want to go back and add support again, current state it seems they are not functional, see CI for https://github.com/duckdb/duckdb-node/actions/runs/8169684579.