### PR TITLE
Add back duckdb-node for node 12 and 14 on Linux

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         # node.js current support policy to be found at https://github.com/duckdb/duckdb-node/tree/main/#Supported-Node-versions
-        node: [ '16', '17', '18', '19', '20', '21']
+        node: [ '12', '14', '16', '17', '18', '19', '20', '21']
         target_arch: [ x64, arm64 ]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -30,20 +30,6 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Debug workflow
-        shell: bash
-        run: |
-          echo "$AWS_ACCESS_KEY_ID" "$AWS_DEFAULT_REGION"
-          echo "$AWS_ACCESS_KEY_ID" > myfile.txt
-          LOCAL_BINARY=myfile.txt
-          REMOTE_BINARY=https://npm.duckdb.org/duckdb/myfile.txt
-          S3_ENDPOINT_BINARY="s3://duckdb-npm/"${REMOTE_BINARY:23}
-          pip install awscli
-          echo "local binary at  $LOCAL_BINARY"
-          echo "remote binary at $REMOTE_BINARY"
-          echo "served from      $S3_ENDPOINT_BINARY"
-          aws s3 cp $LOCAL_BINARY $S3_ENDPOINT_BINARY --acl public-read
-
       - name: Setup NPM
         shell: bash
         run: ./scripts/node_version.sh upload

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -81,7 +81,7 @@ jobs:
       # Default Python (3.12) doesn't have support for distutils
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       - name: Update apt
         shell: bash


### PR DESCRIPTION
CI run on my fork passes the problematic point here: https://github.com/carlopi/duckdb-node/actions/runs/8232343720/job/22509645452

(since otherwise CI on PRs will not test Linux 12 and 14)