### PR TITLE
pointer wrapper constructor

### DIFF
--- a/generate-wrapper.py
+++ b/generate-wrapper.py
@@ -127,7 +127,7 @@ class DuckDBHeaderVisitor(pycparser.c_ast.NodeVisitor):
             return
 
         if isinstance(node.type, pycparser.c_ast.Struct):
-            self.cpp_result += f'exports.Set(Napi::String::New(env, "{name}"), duckdb_node::PointerHolder<{name}>::Init(env, "{name}")->Value());\n'
+            self.cpp_result += f'duckdb_node::PointerHolder<{name}>::Init(env, exports, "{name}");\n'
             self.types_result += f'export class {name} {{}}\n'
             self.c_type_to_ts_type[name] = name
             self.c_type_to_ts_type[f'{name}*'] = name
@@ -263,11 +263,11 @@ if __name__ == "__main__":
         types_out = open('lib/duckdb.d.ts', 'wb')
         
         types_out.write('// placeholder interfaces for pointer types\n'.encode())
-        types_out.write('export interface pointer {}\n'.encode())
-        types_out.write('export interface uint64_pointer extends pointer {}\n'.encode())
         types_out.write('export interface idx_pointer extends pointer {}\n'.encode())
 
         types_out.write('// bindings-defined types\n'.encode())
+        types_out.write('export class pointer {}\n'.encode())
+        types_out.write('export class uint64_pointer {}\n'.encode())
         types_out.write('export class out_string_wrapper {}\n'.encode())
 
         types_out.write('// generated types and functions\n'.encode())

--- a/lib/duckdb.d.ts
+++ b/lib/duckdb.d.ts
@@ -1,8 +1,8 @@
 // placeholder interfaces for pointer types
-export interface pointer {}
-export interface uint64_pointer extends pointer {}
 export interface idx_pointer extends pointer {}
 // bindings-defined types
+export class pointer {}
+export class uint64_pointer {}
 export class out_string_wrapper {}
 // generated types and functions
 export enum duckdb_type {

--- a/src/duckdb_node.cpp
+++ b/src/duckdb_node.cpp
@@ -56,16 +56,17 @@ public:
 	DuckDBNodeNative(Napi::Env env, Napi::Object exports) {
 		RegisterGenerated(env, exports);
 
+		duckdb_node::PointerHolder<void *>::Init(env, exports, "pointer");
+		duckdb_node::PointerHolder<uint64_t *>::Init(env, exports, "uint64_pointer");
+		// TODO: add idx_pointer?
+		duckdb_node::PointerHolder<duckdb_node::out_string_wrapper>::Init(env, exports, "out_string_wrapper");
+
 		exports.Set(Napi::String::New(env, "sizeof_bool"), Napi::Number::New(env, sizeof(bool)));
-
 		exports.Set(Napi::String::New(env, "copy_buffer"), Napi::Function::New<CopyBuffer>(env));
-
 		exports.Set(Napi::String::New(env, "copy_buffer_double"), Napi::Function::New<CopyBufferDouble>(env));
-
-		exports.Set(
-		    Napi::String::New(env, "out_string_wrapper"),
-		    duckdb_node::PointerHolder<duckdb_node::out_string_wrapper>::Init(env, "out_string_wrapper")->Value());
 		exports.Set(Napi::String::New(env, "out_get_string"), Napi::Function::New<OutGetString>(env));
+
+		// for binding; not exposed in TypeScript
 		exports.Set(Napi::String::New(env, "initialize"), Napi::Function::New<Initialize>(env));
 	}
 };

--- a/src/duckdb_node_generated.cpp
+++ b/src/duckdb_node_generated.cpp
@@ -93,76 +93,40 @@ static void RegisterGenerated(Napi::Env env, Napi::Object exports) {
 	exports.DefineProperty(
 	    Napi::PropertyDescriptor::Value("duckdb_statement_type", duckdb_statement_type_enum,
 	                                    static_cast<napi_property_attributes>(napi_enumerable | napi_configurable)));
-	exports.Set(Napi::String::New(env, "duckdb_date"),
-	            duckdb_node::PointerHolder<duckdb_date>::Init(env, "duckdb_date")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_date_struct"),
-	            duckdb_node::PointerHolder<duckdb_date_struct>::Init(env, "duckdb_date_struct")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_time"),
-	            duckdb_node::PointerHolder<duckdb_time>::Init(env, "duckdb_time")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_time_struct"),
-	            duckdb_node::PointerHolder<duckdb_time_struct>::Init(env, "duckdb_time_struct")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_time_tz"),
-	            duckdb_node::PointerHolder<duckdb_time_tz>::Init(env, "duckdb_time_tz")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_time_tz_struct"),
-	            duckdb_node::PointerHolder<duckdb_time_tz_struct>::Init(env, "duckdb_time_tz_struct")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_timestamp"),
-	            duckdb_node::PointerHolder<duckdb_timestamp>::Init(env, "duckdb_timestamp")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_timestamp_struct"),
-	            duckdb_node::PointerHolder<duckdb_timestamp_struct>::Init(env, "duckdb_timestamp_struct")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_interval"),
-	            duckdb_node::PointerHolder<duckdb_interval>::Init(env, "duckdb_interval")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_hugeint"),
-	            duckdb_node::PointerHolder<duckdb_hugeint>::Init(env, "duckdb_hugeint")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_uhugeint"),
-	            duckdb_node::PointerHolder<duckdb_uhugeint>::Init(env, "duckdb_uhugeint")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_decimal"),
-	            duckdb_node::PointerHolder<duckdb_decimal>::Init(env, "duckdb_decimal")->Value());
-	exports.Set(
-	    Napi::String::New(env, "duckdb_query_progress_type"),
-	    duckdb_node::PointerHolder<duckdb_query_progress_type>::Init(env, "duckdb_query_progress_type")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_string_t"),
-	            duckdb_node::PointerHolder<duckdb_string_t>::Init(env, "duckdb_string_t")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_list_entry"),
-	            duckdb_node::PointerHolder<duckdb_list_entry>::Init(env, "duckdb_list_entry")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_column"),
-	            duckdb_node::PointerHolder<duckdb_column>::Init(env, "duckdb_column")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_vector"),
-	            duckdb_node::PointerHolder<duckdb_vector>::Init(env, "duckdb_vector")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_string"),
-	            duckdb_node::PointerHolder<duckdb_string>::Init(env, "duckdb_string")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_blob"),
-	            duckdb_node::PointerHolder<duckdb_blob>::Init(env, "duckdb_blob")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_result"),
-	            duckdb_node::PointerHolder<duckdb_result>::Init(env, "duckdb_result")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_database"),
-	            duckdb_node::PointerHolder<duckdb_database>::Init(env, "duckdb_database")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_connection"),
-	            duckdb_node::PointerHolder<duckdb_connection>::Init(env, "duckdb_connection")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_prepared_statement"),
-	            duckdb_node::PointerHolder<duckdb_prepared_statement>::Init(env, "duckdb_prepared_statement")->Value());
-	exports.Set(
-	    Napi::String::New(env, "duckdb_extracted_statements"),
-	    duckdb_node::PointerHolder<duckdb_extracted_statements>::Init(env, "duckdb_extracted_statements")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_pending_result"),
-	            duckdb_node::PointerHolder<duckdb_pending_result>::Init(env, "duckdb_pending_result")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_appender"),
-	            duckdb_node::PointerHolder<duckdb_appender>::Init(env, "duckdb_appender")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_config"),
-	            duckdb_node::PointerHolder<duckdb_config>::Init(env, "duckdb_config")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_logical_type"),
-	            duckdb_node::PointerHolder<duckdb_logical_type>::Init(env, "duckdb_logical_type")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_data_chunk"),
-	            duckdb_node::PointerHolder<duckdb_data_chunk>::Init(env, "duckdb_data_chunk")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_value"),
-	            duckdb_node::PointerHolder<duckdb_value>::Init(env, "duckdb_value")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_arrow"),
-	            duckdb_node::PointerHolder<duckdb_arrow>::Init(env, "duckdb_arrow")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_arrow_stream"),
-	            duckdb_node::PointerHolder<duckdb_arrow_stream>::Init(env, "duckdb_arrow_stream")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_arrow_schema"),
-	            duckdb_node::PointerHolder<duckdb_arrow_schema>::Init(env, "duckdb_arrow_schema")->Value());
-	exports.Set(Napi::String::New(env, "duckdb_arrow_array"),
-	            duckdb_node::PointerHolder<duckdb_arrow_array>::Init(env, "duckdb_arrow_array")->Value());
+	duckdb_node::PointerHolder<duckdb_date>::Init(env, exports, "duckdb_date");
+	duckdb_node::PointerHolder<duckdb_date_struct>::Init(env, exports, "duckdb_date_struct");
+	duckdb_node::PointerHolder<duckdb_time>::Init(env, exports, "duckdb_time");
+	duckdb_node::PointerHolder<duckdb_time_struct>::Init(env, exports, "duckdb_time_struct");
+	duckdb_node::PointerHolder<duckdb_time_tz>::Init(env, exports, "duckdb_time_tz");
+	duckdb_node::PointerHolder<duckdb_time_tz_struct>::Init(env, exports, "duckdb_time_tz_struct");
+	duckdb_node::PointerHolder<duckdb_timestamp>::Init(env, exports, "duckdb_timestamp");
+	duckdb_node::PointerHolder<duckdb_timestamp_struct>::Init(env, exports, "duckdb_timestamp_struct");
+	duckdb_node::PointerHolder<duckdb_interval>::Init(env, exports, "duckdb_interval");
+	duckdb_node::PointerHolder<duckdb_hugeint>::Init(env, exports, "duckdb_hugeint");
+	duckdb_node::PointerHolder<duckdb_uhugeint>::Init(env, exports, "duckdb_uhugeint");
+	duckdb_node::PointerHolder<duckdb_decimal>::Init(env, exports, "duckdb_decimal");
+	duckdb_node::PointerHolder<duckdb_query_progress_type>::Init(env, exports, "duckdb_query_progress_type");
+	duckdb_node::PointerHolder<duckdb_string_t>::Init(env, exports, "duckdb_string_t");
+	duckdb_node::PointerHolder<duckdb_list_entry>::Init(env, exports, "duckdb_list_entry");
+	duckdb_node::PointerHolder<duckdb_column>::Init(env, exports, "duckdb_column");
+	duckdb_node::PointerHolder<duckdb_vector>::Init(env, exports, "duckdb_vector");
+	duckdb_node::PointerHolder<duckdb_string>::Init(env, exports, "duckdb_string");
+	duckdb_node::PointerHolder<duckdb_blob>::Init(env, exports, "duckdb_blob");
+	duckdb_node::PointerHolder<duckdb_result>::Init(env, exports, "duckdb_result");
+	duckdb_node::PointerHolder<duckdb_database>::Init(env, exports, "duckdb_database");
+	duckdb_node::PointerHolder<duckdb_connection>::Init(env, exports, "duckdb_connection");
+	duckdb_node::PointerHolder<duckdb_prepared_statement>::Init(env, exports, "duckdb_prepared_statement");
+	duckdb_node::PointerHolder<duckdb_extracted_statements>::Init(env, exports, "duckdb_extracted_statements");
+	duckdb_node::PointerHolder<duckdb_pending_result>::Init(env, exports, "duckdb_pending_result");
+	duckdb_node::PointerHolder<duckdb_appender>::Init(env, exports, "duckdb_appender");
+	duckdb_node::PointerHolder<duckdb_config>::Init(env, exports, "duckdb_config");
+	duckdb_node::PointerHolder<duckdb_logical_type>::Init(env, exports, "duckdb_logical_type");
+	duckdb_node::PointerHolder<duckdb_data_chunk>::Init(env, exports, "duckdb_data_chunk");
+	duckdb_node::PointerHolder<duckdb_value>::Init(env, exports, "duckdb_value");
+	duckdb_node::PointerHolder<duckdb_arrow>::Init(env, exports, "duckdb_arrow");
+	duckdb_node::PointerHolder<duckdb_arrow_stream>::Init(env, exports, "duckdb_arrow_stream");
+	duckdb_node::PointerHolder<duckdb_arrow_schema>::Init(env, exports, "duckdb_arrow_schema");
+	duckdb_node::PointerHolder<duckdb_arrow_array>::Init(env, exports, "duckdb_arrow_array");
 	exports.Set(Napi::String::New(env, "duckdb_open"),
 	            Napi::Function::New<duckdb_node::FunctionWrappers::AsyncFunctionWrapper2<
 	                duckdb_state, const char *, duckdb_database *, "duckdb_open">>(env));


### PR DESCRIPTION
Use the actual constructor of the JS object when creating a new PointerWrapper instance in NewAndSet.

Generate actual JS classes for the `void *` and `uint64_t *` PointerWrapper types (e.g. `pointer` and `uint64_pointer`).

Also simplify use of PointerWrapper::Init by taking the object to which to add the export.