### PR TITLE
Skip jsdoc checks on windows due to https://github.com/nodejs/node/is…

### DIFF
--- a/test/jsdoc.test.ts
+++ b/test/jsdoc.test.ts
@@ -23,6 +23,8 @@ export interface Node {
   longname: string;
   scope: string;
 }
+
+if (process?.platform != 'win32') {
 describe("JSDoc contains all methods", () => {
   let docs: Node[];
   before(async () => {
@@ -57,3 +59,4 @@ describe("JSDoc contains all methods", () => {
     checkDocs(duckdb, 'module:duckdb');
   });
 });
+}


### PR DESCRIPTION
See: https://github.com/nodejs/node/issues/52554, whether node changed an API that lead to this crash.

Failure was like:
  1) JSDoc contains all methods
       "before all" hook for "Database":
     Error: spawn EINVAL
      at ChildProcess.spawn (node:internal/child_process:414:11)
      at spawn (node:child_process:761:9)
      at execFile (node:child_process:351:17)
      at jsdocParser (node_modules\jsdoc3-parser\index.js:58:3)
      at node:internal/util:441:7
      at new Promise (<anonymous>)
      at jsdocParser (node:internal/util:427:12)

unsure whether jsdocParser can be bumped, but looks to be broken still.