### PR TITLE
Enable also node 22

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         # node.js current support policy to be found at https://github.com/duckdb/duckdb-node/tree/main/#Supported-Node-versions
-        node: [ '12', '14', '16', '17', '18', '19', '20', '21']
+        node: [ '12', '14', '16', '17', '18', '19', '20', '21', '22']
         target_arch: [ x64, arm64 ]
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
@@ -124,7 +124,7 @@ jobs:
     strategy:
       matrix:
         target_arch: [ x64, arm64 ]
-        node: [ '16', '17', '18', '19', '20', '21']
+        node: [ '16', '17', '18', '19', '20', '21', '22']
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
         exclude:
@@ -189,7 +189,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [ '16', '17', '18', '19', '20', '21']
+        node: [ '16', '17', '18', '19', '20', '21', '22']
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
         exclude:


### PR DESCRIPTION
Node 22 is now available: https://nodejs.org/en/blog/announcements/v22-release-announce