### PR TITLE
Build macos x86 on macos-13 runners

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -115,15 +115,77 @@ jobs:
         shell: bash
         run: ./scripts/node_build.sh ${{ matrix.node }}
 
-  osx-nodejs:
-    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb-node'
+  osx-nodejs-arm64:
     name: node.js OSX
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: set-up-npm
     continue-on-error: ${{ matrix.node != '18' && matrix.node != '20' && matrix.node != '21' }}
     strategy:
       matrix:
-        target_arch: [ x64, arm64 ]
+        target_arch: [ arm64 ]
+        node: [ '16', '17', '18', '19', '20', '21', '22']
+        isRelease:
+          - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+        exclude:
+          - isRelease: false
+            node: 12
+          - isRelease: false
+            node: 14
+          - isRelease: false
+            node: 16
+          - isRelease: false
+            node: 17
+          - isRelease: false
+            node: 19
+          - target_arch: arm64
+            node: 12
+          - target_arch: arm64
+            node: 14
+        # these older versions of NodeJS don't have M1 support
+
+    env:
+      TARGET_ARCH: ${{ matrix.target_arch }}
+      DUCKDB_NODE_BUILD_CACHE: 0
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # Default Python (3.12) doesn't have support for distutils
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}-${{ matrix.target_arch }}
+          save: ${{ ( github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb-node' ) && ( matrix.node == '19' ) }}
+
+      - name: Downgrade curl # fixes a bug with the brew curl that lead to failed downloads
+        shell: bash
+        run: |
+          brew uninstall --ignore-dependencies curl
+          which curl
+
+      - name: Setup
+        shell: bash
+        run: ./scripts/node_version.sh
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
+
+      - name: Node ${{ matrix.node }}
+        shell: bash
+        run: ./scripts/node_build.sh ${{ matrix.node }}
+
+  osx-nodejs-x64:
+    name: node.js OSX
+    runs-on: macos-13
+    needs: set-up-npm
+    continue-on-error: ${{ matrix.node != '18' && matrix.node != '20' && matrix.node != '21' }}
+    strategy:
+      matrix:
+        target_arch: [ x64 ]
         node: [ '16', '17', '18', '19', '20', '21', '22']
         isRelease:
           - ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -313,3 +313,32 @@ jobs:
       - name: Node
         shell: bash
         run: ./scripts/node_build_win.sh
+
+  test_matrix:
+    needs:
+      - linux-nodejs
+      - osx-nodejs-arm64
+      - osx-nodejs-x64
+      - win-nodejs
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, ubuntu-22.04, ubuntu-20.04, windows-2019, macos-12, macos-13, macos-14]
+        version: [20]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.version }}
+
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: examples
+
+      - name: Install duckdb
+        run: |
+          npm install duckdb@next
+
+      - name: Run minor test
+        shell: bash
+        run: |
+          node examples/example.js

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,0 +1,10 @@
+var duckdb = require('duckdb');
+
+var db = new duckdb.Database(':memory:'); // or a file name for a persistent DB
+
+db.all('SELECT 42 AS fortytwo', function(err, res) {
+  if (err) {
+    console.warn(err);
+  }
+  console.log(res[0].fortytwo)
+});


### PR DESCRIPTION
There is something off with node-pre-gyp that do not respect the target but directly queries the underlying platform.
Bridge solution is building both flavors natively using two different runners.

Closes https://github.com/duckdb/duckdb-node/issues/84
Closes https://github.com/duckdb/duckdb-node/issues/86