### PR TITLE
Remove version from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "duckdb",
   "main": "./lib/duckdb.js",
   "types": "./lib/duckdb.d.ts",
-  "version": "0.0.2-dev5.0",
   "description": "DuckDB node.js API",
   "gypfile": true,
   "dependencies": {


### PR DESCRIPTION
Towards fixing https://github.com/duckdb/duckdb-node/issues/95.

Version as 0.0.2 is clearly wrong, I hope that this is enough to have it autogenerated.