### PR TITLE
Set version to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "duckdb",
   "main": "./lib/duckdb.js",
   "types": "./lib/duckdb.d.ts",
-  "version": "0.0.2-dev5.0",
+  "version": "1.1.2",
   "description": "DuckDB node.js API",
   "gypfile": true,
   "dependencies": {


### PR DESCRIPTION
This is relevant only for yarn that do not override.

I looked at #95, problem is that yarn try to use the version in package.json to avoid rebuilding, otherwise trowing noisy warnings or possibly errors.

I think proper solution would require to keep version in package.json to the git version, but it's too much complexity for little gain.

Removing the version altogether do not seems to be an option, given build tools expect to find something (even just for ignoring it).

Unsure of the way out, recent way seems better that old / non existing, unsure if we want to bump manually or automate.

I think merging + tagging would work.