### PR TITLE
Creating Arrow Table Function and View with the Relational API

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -500,9 +500,7 @@ Napi::Value Connection::RegisterBuffer(const Napi::CallbackInfo &info) {
 	}
 
 	array_references[name] = Napi::Persistent(array);
-	auto &connection = Get<Connection>();
-	auto &con = *connection.connection;
-	auto &db = *con->context->db;
+	auto &db = *connection->context->db;
 
 	vector<duckdb::Value> values;
 	


### PR DESCRIPTION
This PR changes the Arrow IPC functionality to create the call to `scan_arrow_ipc` to be done via the Relational API, instead of constructing the SQL Query. This is now necessary since in the new Arrow Extension the `scan_arrow_ipc` function will be marked with a Pointer Logical Type to avoid manual access through SQL.

I've tested this PR with https://github.com/paleolimbot/duckdb-nanoarrow/pull/15