### PR TITLE
Switch to npm trusted publishing

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -17,25 +17,28 @@ env:
 
 jobs:
   set-up-npm:
-    name: Set up NPM
+    name: Upload to NPM
     runs-on: ubuntu-22.04
     env:
       DUCKDB_NODE_BUILD_CACHE: 0
+    permissions: # only this job has permission to upload to npm using trusted publishing
+      id-token: write  # Required for OIDC
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-node@v4
         with:
-          python-version: '3.11'
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup NPM
         shell: bash
         run: ./scripts/node_version.sh upload
         env:
           DUCKDB_NODE_BUILD_CACHE: 0  # create a standalone package
-          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
 
   linux-nodejs:
     name: node.js Linux

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -13,7 +13,7 @@ env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   AWS_ACCESS_KEY_ID: ${{secrets.S3_DUCKDB_NODE_ID}}
   AWS_SECRET_ACCESS_KEY: ${{secrets.S3_DUCKDB_NODE_KEY}}
-  AWS_DEFAULT_REGION: us-east-1
+  AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_NODE_ENDPOINT }}
 
 jobs:
   set-up-npm:

--- a/scripts/node_version.sh
+++ b/scripts/node_version.sh
@@ -28,6 +28,5 @@ npm pack --dry-run
 # upload to npm, maybe
 if [[ "$GITHUB_REF" =~ ^(refs/heads/main|refs/tags/v.+)$ && "$1" = "upload" ]] ; then
 	npm version
-	npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
 	npm publish --access public $TAG
 fi


### PR DESCRIPTION
Triggered by [this](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/)
we decided to switch to using [NPM trusted publishing](https://docs.npmjs.com/trusted-publishers). 

The NPM settings are already there:

<img width="805" height="229" alt="Screenshot 2025-10-14 at 09 13 35" src="https://github.com/user-attachments/assets/a2666374-00fc-4f4c-a80c-7d330fba26ef" />

The changes in this PR should be enough. Once merged, we have to disable token upload for the `duckdb` npm package. 

CC @jraymakers  
